### PR TITLE
Refactor types.ts to align SalesOrder with Deliveries

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -42,7 +42,6 @@ const menuOpenDefaultState: MenuOpen = {
   hr: false
 };
 
-const submenuTypographyProps = { fontSize: '0.8em' };
 
 const Sidebar = ({ sidebarWidth }: SidebarProps) => {
   const [menuOpen, setMenuOpen] =
@@ -107,16 +106,8 @@ const Sidebar = ({ sidebarWidth }: SidebarProps) => {
             toggleOpen={(open) => toggleMenuOpen('sales', open)}
             icon={<LocalGroceryStore />}
           >
-            <ListItemLink primary='Dashboard' to='/sales/dashboard' />
-          </NestedList>
-
-          <NestedList
-            title={'Orders'}
-            open={menuOpen.order}
-            toggleOpen={(open) => toggleMenuOpen('order', open)}
-            icon={<PointOfSale />}
-          >
             <List component='div' disablePadding>
+              <ListItemLink primary='Dashboard' to='/sales/dashboard' />
               <ListItemLink
                 primary='Create Orders'
                 to='/orders/createNewOrder'

--- a/src/models/types/index.ts
+++ b/src/models/types/index.ts
@@ -151,9 +151,9 @@ export interface SalesOrder {
   customerName: string;
   amount: number;
   delivery: DeliveryOrder;
-  orderLineItems: LineItem[];
+  salesOrderItems: SalesOrderItem[];
 }
-export interface LineItem {
+export interface SalesOrderItem {
   saleOrderId: number;
   price: number;
   quantity: number;

--- a/src/models/types/index.ts
+++ b/src/models/types/index.ts
@@ -25,11 +25,18 @@ export enum FulfilmentStatus {
 }
 
 export enum OrderStatus {
-  CREATED = 'CREATED'
+  PLACED = 'PLACED',
+  PAID = 'PAID',
+  PREPARING = 'PREPARING',
+  PREPARED = 'PREPARED',
+  SHIPPED = 'SHIPPED',
+  DELIVERED = 'DELIVERED', 
   //not completed, need to wait for backend
 }
 
 export enum DeliveryStatus {
+  READYFORDELIVERY = 'READY_FOR_DELIVERY',
+  DELIVERYINPROGRESS = 'DELIVERY_IN_PROGRESS',
   DELIVERED = 'DELIVERED'
   //not completed, need to wait for backend
 }
@@ -37,7 +44,15 @@ export enum DeliveryStatus {
 export enum ShippingType {
   MANUAL = 'MANUAL',
   SHIPPIT = 'SHIPPIT',
-  SHOPIFY = 'SHOPIFY'
+  NINJAVAN = 'NINJAVAN',
+  GRAB = 'GRAB'
+}
+
+export enum PlatformType {
+  MANUAL = 'MANUAL',
+  SHOPIFY = 'SHOPIFY',
+  REDMART = 'REDMART',
+  SHOPEE = 'SHOPEE'
 }
 
 export interface User {
@@ -119,15 +134,22 @@ export interface Supplier {
   name: string;
   address: string;
 }
-
 export interface DeliveryOrder {
   id: number;
-  orderStatus: OrderStatus;
   deliveryStatus: DeliveryStatus;
   shippingDate: Date;
   shippingAddress: string;
   shippingType: ShippingType;
   currentLocation: string;
   eta: Date;
-  paymentId: number;
+}
+export interface SalesOrder { 
+  id: number;
+  customerName: string;
+  createdTimestamp: Date;
+  amount: number;
+  status: OrderStatus;
+  orderLineItems: Product[];
+  platformType: PlatformType;
+  delivery: DeliveryOrder;
 }

--- a/src/models/types/index.ts
+++ b/src/models/types/index.ts
@@ -145,11 +145,17 @@ export interface DeliveryOrder {
 }
 export interface SalesOrder { 
   id: number;
-  customerName: string;
-  createdTimestamp: Date;
-  amount: number;
-  status: OrderStatus;
-  orderLineItems: Product[];
   platformType: PlatformType;
+  status: OrderStatus;
+  createdTime: Date;
+  customerName: string;
+  amount: number;
   delivery: DeliveryOrder;
+  orderLineItems: LineItem[];
+}
+export interface LineItem {
+  saleOrderId: number;
+  price: number;
+  quantity: number;
+  product: Product;
 }


### PR DESCRIPTION
refactor: updated types.ts, includes interface for SalesOrder and DeliveryOrder, will use as placeholders for now and confirm with BE once they are done. 
UI: shifted Order under Sales