### PR TITLE
Rectify Bundle Items bug and added nav to delivery details

### DIFF
--- a/src/pages/sales/SalesOrderDetails.tsx
+++ b/src/pages/sales/SalesOrderDetails.tsx
@@ -113,7 +113,7 @@ const SalesOrderDetails = () => {
             </>
           );
         } else if (
-          params.row.salesOrderBundleItems.length > 0 &&
+          Array.from(params.row.salesOrderBundleItems).length > 0 &&
           salesOrder?.orderStatus === OrderStatus.PREPARING
         ) {
           return (

--- a/src/pages/sales/SalesOrderDetails.tsx
+++ b/src/pages/sales/SalesOrderDetails.tsx
@@ -116,7 +116,6 @@ const SalesOrderDetails = () => {
           Array.from(params.row.salesOrderBundleItems).length > 0 &&
           salesOrder?.orderStatus === OrderStatus.PREPARING
         ) {
-          
           return (
             <>
               <Button
@@ -124,9 +123,7 @@ const SalesOrderDetails = () => {
                   setEditSalesOrderBundleItems(
                     params.row.salesOrderBundleItems
                   );
-                  setSaleOrderLineItemId(
-                    params.row.id
-                  );
+                  setSaleOrderLineItemId(params.row.id);
                   setShowCurrentBundleModal(true);
                 }}
                 variant='contained'
@@ -140,6 +137,18 @@ const SalesOrderDetails = () => {
       }
     }
   ];
+
+  useEffect(() => {
+    if (editSalesOrderBundleItems) {
+      setAvailBundleProducts(
+        products.filter((product) => {
+          return !editSalesOrderBundleItems.some(bundleItem => {
+            return product.name === bundleItem.productName;
+          });
+        })
+      );
+    }
+  }, [editSalesOrderBundleItems, products]);
 
   useEffect(() => {
     setLoading(true);
@@ -415,7 +424,7 @@ const SalesOrderDetails = () => {
 
   const saveChangesToBundle = () => {
     const temp = [...editSalesOrderItems];
-    if(editSalesOrderBundleItems.length > 0) {
+    if (editSalesOrderBundleItems.length > 0) {
       const oldSaleOrderItem = JSON.parse(
         JSON.stringify(
           temp.find((item) => {

--- a/src/pages/sales/SalesOrderDetails.tsx
+++ b/src/pages/sales/SalesOrderDetails.tsx
@@ -212,8 +212,7 @@ const SalesOrderDetails = () => {
       } else if (
         activeStep > 3 &&
         (salesOrder?.platformType === PlatformType.SHOPIFY ||
-          salesOrder?.platformType === PlatformType.OTHERS ||
-          salesOrder?.platformType === PlatformType.SHOPEE)
+          salesOrder?.platformType === PlatformType.OTHERS)
       ) {
         salesOrder.id &&
         asyncFetchCallback(
@@ -498,10 +497,10 @@ const SalesOrderDetails = () => {
                   variant='contained'
                   size='medium'
                   onClick={nextStep}
-                  // disabled={
-                  //   salesOrder?.platformType === PlatformType.SHOPEE &&
-                  //   activeStep > 2
-                  // }
+                  disabled={
+                    salesOrder?.platformType === PlatformType.SHOPEE &&
+                    activeStep > 2
+                  }
                 >
                   {steps[activeStep].nextAction}
                 </Button>

--- a/src/pages/sales/SalesOrderDetails.tsx
+++ b/src/pages/sales/SalesOrderDetails.tsx
@@ -116,6 +116,7 @@ const SalesOrderDetails = () => {
           Array.from(params.row.salesOrderBundleItems).length > 0 &&
           salesOrder?.orderStatus === OrderStatus.PREPARING
         ) {
+          
           return (
             <>
               <Button
@@ -289,7 +290,8 @@ const SalesOrderDetails = () => {
         price: 0,
         isNewAdded: true,
         salesOrderId: salesOrder?.id!,
-        createdTime: salesOrder?.createdTime
+        createdTime: salesOrder?.createdTime,
+        salesOrderBundleItems: []
       };
     });
   };

--- a/src/pages/sales/ViewCurrentBundleModal.tsx
+++ b/src/pages/sales/ViewCurrentBundleModal.tsx
@@ -25,7 +25,7 @@ type ViewCurrentBundleModalProps = {
     key: string
   ) => void;
   addNewItemToBundleItems: () => void;
-  removeItemFromBundleItems: (productName: String, salesOrderItemId: number) => void;
+  removeItemFromBundleItems: (productName: String, salesOrderItemId: number, idx: number) => void;
   onSave: () => void;
 };
 
@@ -57,21 +57,19 @@ const ViewCurrentBundleModal = ({
       align: 'center',
       flex: 1,
       renderCell: (params) => {
-        if (params.row.isNewAdded) {
           return (
             <>
               <Button
                 variant='contained'
                 size='medium'
                 onClick={() =>
-                  removeItemFromBundleItems(params.row.productName, params.row.salesOrderItemId)
+                  removeItemFromBundleItems(params.row.productName, params.row.salesOrderItemId, params.row.id)
                 }
               >
                 Remove Item
               </Button>
             </>
           );
-        }
       }
     }
   ];

--- a/src/pages/sales/ViewCurrentBundleModal.tsx
+++ b/src/pages/sales/ViewCurrentBundleModal.tsx
@@ -19,7 +19,7 @@ type ViewCurrentBundleModalProps = {
   open: boolean;
   onClose: () => void;
   focusPassthrough?: boolean;
-  editSalesOrderBundleItems?: SalesOrderBundleItem[];
+  editSalesOrderBundleItems: SalesOrderBundleItem[];
   availProducts: Product[];
   updateNewSalesOrderBundleItem: (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -47,7 +47,7 @@ const ViewCurrentBundleModal = ({
 }: ViewCurrentBundleModalProps) => {
   const [prodName, setProdName] = useState<String>('');
   const [quantity, setQuantity] = useState<number>(0);
-  const [alert, setAlert] = useState<AlertType | null>(null);
+  const [bundleAlert, setBundleAlert] = useState<AlertType | null>(null);
   const columns: GridColDef[] = [
     { field: 'productName', headerName: 'Product Name', flex: 1 },
     {
@@ -85,10 +85,12 @@ const ViewCurrentBundleModal = ({
   ];
 
   useEffect(() => {
-    if (editSalesOrderBundleItems && editSalesOrderBundleItems.length < 1) {
-      setAlert({
-        severity: 'error',
-        message: 'Bundle cannot be empty. Please add an item to the bundle.'
+    if (
+     editSalesOrderBundleItems?.length! < 1
+    ) {
+      setBundleAlert({
+        severity: 'info',
+        message: `Note: Bundle cannot be empty. If so, please ensure that there are items in this bundle.`
       });
     }
   }, [editSalesOrderBundleItems]);
@@ -113,7 +115,10 @@ const ViewCurrentBundleModal = ({
                 These are the items in your bundle.
               </DialogContentText>
 
-              <TimeoutAlert alert={alert} clearAlert={() => setAlert(null)} />
+              <TimeoutAlert
+                alert={bundleAlert}
+                clearAlert={() => setBundleAlert(null)}
+              />
               <DataGrid
                 columns={columns}
                 rows={editSalesOrderBundleItems!}

--- a/src/pages/sales/ViewCurrentBundleModal.tsx
+++ b/src/pages/sales/ViewCurrentBundleModal.tsx
@@ -8,11 +8,12 @@ import {
   MenuItem,
   TextField
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Product, SalesOrderBundleItem } from 'src/models/types';
 import '../../styles/pages/sales/orders.scss';
 import '../../styles/common/common.scss';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import TimeoutAlert, { AlertType } from 'src/components/common/TimeoutAlert';
 
 type ViewCurrentBundleModalProps = {
   open: boolean;
@@ -25,7 +26,11 @@ type ViewCurrentBundleModalProps = {
     key: string
   ) => void;
   addNewItemToBundleItems: () => void;
-  removeItemFromBundleItems: (productName: String, salesOrderItemId: number, idx: number) => void;
+  removeItemFromBundleItems: (
+    productName: String,
+    salesOrderItemId: number,
+    idx: number
+  ) => void;
   onSave: () => void;
 };
 
@@ -42,6 +47,7 @@ const ViewCurrentBundleModal = ({
 }: ViewCurrentBundleModalProps) => {
   const [prodName, setProdName] = useState<String>('');
   const [quantity, setQuantity] = useState<number>(0);
+  const [alert, setAlert] = useState<AlertType | null>(null);
   const columns: GridColDef[] = [
     { field: 'productName', headerName: 'Product Name', flex: 1 },
     {
@@ -57,22 +63,35 @@ const ViewCurrentBundleModal = ({
       align: 'center',
       flex: 1,
       renderCell: (params) => {
-          return (
-            <>
-              <Button
-                variant='contained'
-                size='medium'
-                onClick={() =>
-                  removeItemFromBundleItems(params.row.productName, params.row.salesOrderItemId, params.row.id)
-                }
-              >
-                Remove Item
-              </Button>
-            </>
-          );
+        return (
+          <>
+            <Button
+              variant='contained'
+              size='medium'
+              onClick={() => {
+                removeItemFromBundleItems(
+                  params.row.productName,
+                  params.row.salesOrderItemId,
+                  params.row.id
+                );
+              }}
+            >
+              Remove Item
+            </Button>
+          </>
+        );
       }
     }
   ];
+
+  useEffect(() => {
+    if (editSalesOrderBundleItems && editSalesOrderBundleItems.length < 1) {
+      setAlert({
+        severity: 'error',
+        message: 'Bundle cannot be empty. Please add an item to the bundle.'
+      });
+    }
+  }, [editSalesOrderBundleItems]);
 
   return (
     <>
@@ -94,6 +113,7 @@ const ViewCurrentBundleModal = ({
                 These are the items in your bundle.
               </DialogContentText>
 
+              <TimeoutAlert alert={alert} clearAlert={() => setAlert(null)} />
               <DataGrid
                 columns={columns}
                 rows={editSalesOrderBundleItems!}
@@ -166,6 +186,7 @@ const ViewCurrentBundleModal = ({
                 type='submit'
                 autoFocus={focusPassthrough}
                 onClick={onSave}
+                disabled={editSalesOrderBundleItems?.length! < 1}
               >
                 Save Changes
               </Button>

--- a/src/services/salesService.ts
+++ b/src/services/salesService.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import {
   DailySales,
+  DeliveryOrder,
   OrderStatus,
   SalesBestseller,
   SalesOrder,
@@ -85,3 +86,9 @@ export const updateSalesOrderStatusSvc = (
     .put(`${apiRoot}/sales/status`, { id, orderStatus })
     .then((res) => res.data);
 };
+
+export const getDeliveryTypeSvc = (id: number): Promise<DeliveryOrder> => {
+  return axios
+  .get(`${apiRoot}/delivery/sales/${id}`)
+  .then((res) => res.data);
+}


### PR DESCRIPTION
fix: Update codes to handle bug where removed bundleItems are not persisting correctly.
fix: Update saveChanges bug where it is repeatedly adding new bundle items in erroneously
fix: added routing from SalesOrderDetails to DeliveryDetails based on API call from BE to determine ShippingType

tbc:
- need to iron out with delivery, that there will be no instance a SalesOrder exist with OrderStatus >= READY_FOR_DELIVERY without a DeliveryOrder created.
- need to iron out with delivery, that for Shopee orders, there will be no deliveryDetails. 
- need to iron out with delivery, that only Shippit orders & B2B (PlatformType.Others) will have deliveryOrder created