### PR TITLE
UI Fixes from SR2

### DIFF
--- a/src/components/sales/order/SalesOrderTable.tsx
+++ b/src/components/sales/order/SalesOrderTable.tsx
@@ -49,7 +49,7 @@ const Row = ({ row }: { row: SalesOrder }) => {
             size='small'
             onClick={() => setOpen(!open)}
           >
-            {open ? <KeyboardArrowDown/> : <KeyboardArrowUp  />}
+            {open ? <KeyboardArrowDown /> : <KeyboardArrowUp />}
           </IconButton>
         </TableCell>
         <TableCell component='th' scope='row' align='center'>
@@ -63,7 +63,15 @@ const Row = ({ row }: { row: SalesOrder }) => {
           <PlatformChip salesOrder={row!} />
         </TableCell>
         <TableCell align='center'>${row.amount.toFixed(2)}</TableCell>
-        <TableCell align='center'>{row.customerAddress ?? 'NA'}</TableCell>
+        <TableCell
+          align='center'
+          style={{
+            whiteSpace: 'normal',
+            wordWrap: 'break-word'
+          }}
+        >
+          {row.customerAddress ?? 'NA'}
+        </TableCell>
         <TableCell align='center'>
           <Button
             variant='contained'

--- a/src/pages/sales/AddSalesOrderItemModal.tsx
+++ b/src/pages/sales/AddSalesOrderItemModal.tsx
@@ -51,7 +51,7 @@ const AddSalesOrderItemModal = ({
         >
           <DialogTitle id='alert-dialog-title'>{title}</DialogTitle>
           <DialogContent>
-            <DialogContentText id='alert-dialog-description'>
+            <DialogContentText id='alert-dialog-description' style={{marginBottom: '10%'}}>
               {body}
             </DialogContentText>
 


### PR DESCRIPTION
style: added bottom margin for add item modal in SalesOrderDetails page, modal does not squeeze the words now. 
style: for sales orders table, added column wrapping for address so it does not overflow. 