### PR TITLE
feat: Implemented bulk order management flow

### DIFF
--- a/src/components/sales/bulkOrder/BulkOrderActionButton.tsx
+++ b/src/components/sales/bulkOrder/BulkOrderActionButton.tsx
@@ -1,0 +1,112 @@
+import { Button } from '@mui/material';
+import _ from 'lodash';
+import { useEffect, useState } from 'react';
+import ConfirmationModal from 'src/components/common/ConfirmationModal';
+import { AlertType } from 'src/components/common/TimeoutAlert';
+import { BulkOrder, BulkOrderStatus, OrderStatus } from 'src/models/types';
+import { updateBulkOrderStatusSvc } from 'src/services/bulkOrderService';
+import asyncFetchCallback from 'src/services/util/asyncFetchCallback';
+import { BulkOrderSteps } from './BulkOrderStepper';
+
+interface props {
+  bulkOrder: BulkOrder;
+  canBulkPrep: boolean;
+  setBulkOrder: (bukkOrder: BulkOrder) => void;
+  setCanBulkPrep: (bool: boolean) => void;
+  setAlert: (value: React.SetStateAction<AlertType | null>) => void;
+}
+
+const BulkOrderActionButton = ({
+  bulkOrder,
+  canBulkPrep,
+  setBulkOrder,
+  setCanBulkPrep,
+  setAlert
+}: props) => {
+  const [activeStep, setActiveStep] = useState<number>(0);
+  const [disableButton, setDisableButton] = useState<boolean>(false);
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
+  const [title, setTitle] = useState<string>('');
+  const [body, setBody] = useState<string>('');
+
+  useEffect(() => {
+    setActiveStep(
+      BulkOrderSteps.findIndex(
+        (step) => bulkOrder.bulkOrderStatus === step.currentState
+      )
+    );
+    if (
+      bulkOrder.bulkOrderStatus === BulkOrderStatus.FULFILLED ||
+      bulkOrder.bulkOrderStatus === BulkOrderStatus.CANCELLED ||
+      bulkOrder.bulkOrderStatus === BulkOrderStatus.PAYMENT_FAILED ||
+      (bulkOrder.bulkOrderStatus === BulkOrderStatus.PAYMENT_SUCCESS &&
+        !bulkOrder.salesOrders.every((order) => {
+          return order.orderStatus === OrderStatus.DELIVERED;
+        }))
+    ) {
+      setDisableButton(true);
+    }
+    if (bulkOrder.bulkOrderStatus === BulkOrderStatus.CREATED) {
+      setTitle('Cancel an order');
+      setBody('Are you sure you want to cancel this order?');
+    } else {
+      setTitle('Complete an order');
+      setBody('Are you sure you want to mark this order as completed?');
+    }
+  }, [bulkOrder.bulkOrderStatus, bulkOrder.salesOrders]);
+
+  const handleNextStep = () => {
+    asyncFetchCallback(
+        updateBulkOrderStatusSvc(bulkOrder?.id!, (bulkOrder.bulkOrderStatus === BulkOrderStatus.CREATED ? BulkOrderStatus.CANCELLED : BulkOrderStatus.FULFILLED)),
+        () => {
+          setBulkOrder({
+            ...bulkOrder!,
+            bulkOrderStatus: (bulkOrder.bulkOrderStatus === BulkOrderStatus.CREATED ? BulkOrderStatus.CANCELLED : BulkOrderStatus.FULFILLED)
+          });
+          setCanBulkPrep(false);
+          setAlert({
+            severity: 'success',
+            message: 'The orders in this bulk order has been updated.'
+          });
+        },
+        () => {
+          setAlert({
+            severity: 'error',
+            message:
+              'Failed to update the orders in this bulk order. Contact the admin.'
+          });
+        }
+      );
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      <ConfirmationModal
+        open={modalOpen}
+        onClose={() => {
+          setModalOpen(false);
+        }}
+        onConfirm={() => handleNextStep()}
+        title={title}
+        body={body}
+      />
+
+      <Button
+        variant='contained'
+        color={
+          bulkOrder.bulkOrderStatus === BulkOrderStatus.CREATED
+            ? 'warning'
+            : 'primary'
+        }
+        size='medium'
+        disabled={disableButton || canBulkPrep}
+        onClick={() => setModalOpen(true)}
+      >
+        {BulkOrderSteps[activeStep].altAction}
+      </Button>
+    </>
+  );
+};
+
+export default BulkOrderActionButton;

--- a/src/components/sales/bulkOrder/BulkOrderStepper.tsx
+++ b/src/components/sales/bulkOrder/BulkOrderStepper.tsx
@@ -1,4 +1,4 @@
-import { Step, StepLabel, Stepper } from '@mui/material';
+import { Step, StepLabel, Stepper, Tooltip } from '@mui/material';
 import { useEffect, useState, useMemo } from 'react';
 import { BulkOrderStatus } from 'src/models/types';
 import {
@@ -18,37 +18,44 @@ export const BulkOrderSteps = [
     label: 'Order Placed',
     icon: <ReceiptLongRounded sx={{ fontSize: 35 }} />,
     nextAction: 'Confirm Payment',
-    tooltip: 'Confirm the payment for this order'
+    altAction: 'Cancel Order',
+    tooltip: 'Once payment has been confirmed, you can begin preparing the order.'
   },
   {
     currentState: BulkOrderStatus.CANCELLED,
     label: 'Order Cancelled',
     icon: <DoDisturbOffRounded sx={{ fontSize: 35 }} />,
     nextAction: 'No Further Actions',
-    tooltip: 'Order has been cancelled, no further actions from your end'
+    altAction: 'No Further Actions',
+    tooltip: 'Order has been cancelled, no further actions from your end.'
   },
   {
     currentState: BulkOrderStatus.PAYMENT_FAILED,
     label: 'Payment Failed',
     icon: <AccountBalanceWalletRounded sx={{ fontSize: 35 }} />,
     nextAction: 'Contact Admin',
-    tooltip: 'Kindly seek admin assitance to retry payment'
+    altAction: 'No Further Actions',
+    tooltip: 'Customers will retry payment, otherwise, there is no actions from your end needed.'
   },
   {
     currentState: BulkOrderStatus.PAYMENT_SUCCESS,
     label: 'Order Paid',
     icon: <AccountBalanceWalletRounded sx={{ fontSize: 35 }} />,
     nextAction: 'Bulk Prepare',
-    tooltip: 'Bulk prepare the orders, otherwise individually prepare each order'
+    altAction: 'Complete Order',
+    tooltip:
+      'Bulk prepare the orders, otherwise individually prepare each order.'
   },
   {
     currentState: BulkOrderStatus.FULFILLED,
     label: 'Order Fulfilled',
     icon: <PlaylistAddCheckCircleRounded sx={{ fontSize: 35 }} />,
     nextAction: 'Back To All Bulk Order',
-    tooltip: 'Order completed, no further actions from your end'
-  },
+    altAction: 'No Further Actions',
+    tooltip: 'Order completed, no further actions from your end.'
+  }
 ];
+
 
 const BulkOrderStepper = ({ bulkOrderStatus }: props) => {
   const [activeStep, setActiveStep] = useState<number>(0);
@@ -94,7 +101,9 @@ const BulkOrderStepper = ({ bulkOrderStatus }: props) => {
     <Stepper activeStep={activeStep} alternativeLabel className='sales-stepper'>
       {statusStepper.map((step) => (
         <Step key={step.label}>
-          <StepLabel icon={step.icon}>{step.label}</StepLabel>
+          <Tooltip title={step.tooltip} enterDelay={300}>
+            <StepLabel icon={step.icon}>{step.label}</StepLabel>
+          </Tooltip>
         </Step>
       ))}
     </Stepper>

--- a/src/components/sales/bulkOrder/bulkOrderGridCol.tsx
+++ b/src/components/sales/bulkOrder/bulkOrderGridCol.tsx
@@ -6,6 +6,8 @@ import '../../../styles/common/actionCells.scss';
 import { useNavigate } from 'react-router';
 import { createSearchParams } from 'react-router-dom';
 import _ from 'lodash';
+import PaymentModeCell from 'src/components/customers/PaymentModeCell';
+import BulkOrderStatusCell from 'src/components/customers/BulkOrderStatusCell';
 
 export const BulkOrderCellAction = ({ id }: GridRenderCellParams) => {
   const navigate = useNavigate();
@@ -50,6 +52,7 @@ export const bulkOrderColumns: GridColDef[] = [
     field: 'paymentMode',
     headerName: 'Payment Mode',
     flex: 1,
+    renderCell: PaymentModeCell,
     valueFormatter: (params) =>
       _.startCase(params.value.toString().toLowerCase())
   },
@@ -57,6 +60,7 @@ export const bulkOrderColumns: GridColDef[] = [
     field: 'bulkOrderStatus',
     headerName: 'Order Status',
     flex: 1,
+    renderCell: BulkOrderStatusCell,
     valueFormatter: (params) =>
       _.startCase(params.value.toString().toLowerCase())
   },

--- a/src/pages/sales/SalesOrderDetails.tsx
+++ b/src/pages/sales/SalesOrderDetails.tsx
@@ -233,7 +233,8 @@ const SalesOrderDetails = () => {
     } else if (
       newStatus === OrderStatus.READY_FOR_DELIVERY &&
       (salesOrder?.platformType === PlatformType.SHOPIFY ||
-        salesOrder?.platformType === PlatformType.OTHERS)
+        salesOrder?.platformType === PlatformType.OTHERS ||
+        salesOrder?.platformType === PlatformType.B2B)
     ) {
       salesOrder.id &&
         navigate({
@@ -245,7 +246,8 @@ const SalesOrderDetails = () => {
     } else if (
       activeStep > 3 &&
       (salesOrder?.platformType === PlatformType.SHOPIFY ||
-        salesOrder?.platformType === PlatformType.OTHERS)
+        salesOrder?.platformType === PlatformType.OTHERS ||
+        salesOrder?.platformType === PlatformType.B2B)
     ) {
       salesOrder.id &&
         asyncFetchCallback(getDeliveryTypeSvc(salesOrder.id), (res) => {

--- a/src/pages/sales/bulkOrders/BulkOrderDetails.tsx
+++ b/src/pages/sales/bulkOrders/BulkOrderDetails.tsx
@@ -4,8 +4,7 @@ import {
   Button,
   IconButton,
   Paper,
-  Tooltip,
-  Typography
+  Tooltip
 } from '@mui/material';
 import TimeoutAlert, { AlertType } from 'src/components/common/TimeoutAlert';
 import { useNavigate } from 'react-router-dom';

--- a/src/pages/sales/bulkOrders/BulkOrderDetails.tsx
+++ b/src/pages/sales/bulkOrders/BulkOrderDetails.tsx
@@ -1,11 +1,5 @@
 import { ChevronLeft } from '@mui/icons-material';
-import {
-  Box,
-  Button,
-  IconButton,
-  Paper,
-  Tooltip
-} from '@mui/material';
+import { Box, Button, IconButton, Paper, Tooltip } from '@mui/material';
 import TimeoutAlert, { AlertType } from 'src/components/common/TimeoutAlert';
 import { useNavigate } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
@@ -26,6 +20,7 @@ import { bulkOrderLineItems } from 'src/components/sales/bulkOrder/bulkOrderGrid
 import { DataGrid } from '@mui/x-data-grid';
 import BulkOrderStepper from 'src/components/sales/bulkOrder/BulkOrderStepper';
 import ConfirmationModal from 'src/components/common/ConfirmationModal';
+import BulkOrderActionButton from 'src/components/sales/bulkOrder/BulkOrderActionButton';
 
 const title = 'Bulk prepare order items';
 const body =
@@ -49,7 +44,6 @@ const BulkOrderDetails = () => {
         if (bo) {
           setBulkOrder(bo);
           setSalesOrders(bo.salesOrders);
-          setLoading(false);
           if (
             bo.salesOrders.some(
               (order) => order.orderStatus === OrderStatus.PAID
@@ -58,6 +52,16 @@ const BulkOrderDetails = () => {
           ) {
             setCanBulkPrep(true);
           }
+
+          if (
+            !(
+              bo.bulkOrderStatus === BulkOrderStatus.PAYMENT_SUCCESS ||
+              bo.bulkOrderStatus === BulkOrderStatus.FULFILLED
+            )
+          ) {
+            bulkOrderLineItems.pop();
+          }
+          setLoading(false);
         } else {
           setAlert({
             severity: 'error',
@@ -81,6 +85,7 @@ const BulkOrderDetails = () => {
             return { ...so, orderStatus: OrderStatus.PREPARED };
           })
         });
+        setCanBulkPrep(false);
         setAlert({
           severity: 'success',
           message: 'The orders in this bulk order has been updated.'
@@ -125,6 +130,15 @@ const BulkOrderDetails = () => {
             <BulkOrderStepper bulkOrderStatus={bulkOrder?.bulkOrderStatus!} />
             <Paper elevation={3} className='sales-action-card '>
               {bulkOrder && <CustomerInfoGrid bulkOrder={bulkOrder!} />}
+              {bulkOrder && (
+                <BulkOrderActionButton
+                  bulkOrder={bulkOrder}
+                  canBulkPrep={canBulkPrep}
+                  setBulkOrder={setBulkOrder}
+                  setCanBulkPrep={setCanBulkPrep}
+                  setAlert={setAlert}
+                />
+              )}
             </Paper>
           </div>
 
@@ -151,7 +165,7 @@ const BulkOrderDetails = () => {
                   <DataGrid
                     style={{ wordWrap: 'break-word' }}
                     columns={bulkOrderLineItems}
-                    rows={bulkOrder.salesOrders ?? []}
+                    rows={bulkOrder.salesOrders}
                     autoHeight
                     pageSize={5}
                     loading={loading}

--- a/src/services/bulkOrderService.ts
+++ b/src/services/bulkOrderService.ts
@@ -1,4 +1,4 @@
-import { BulkOrder } from 'src/models/types';
+import { BulkOrder, BulkOrderStatus } from 'src/models/types';
 import axios from 'axios';
 import apiRoot from './util/apiRoot';
 import { MomentRange } from 'src/utils/dateUtils';
@@ -21,4 +21,8 @@ export const getBulkOrdersByRangeSvc = async (
   return axios
     .post(`${apiRoot}/sales/timefilter`, timeFilter)
     .then((res) => res.data);
+};
+
+export const bulkOrderMassUpdate = async (id: number, bulkOrderStatus: BulkOrderStatus): Promise<any> => {
+  return axios.put(`${apiRoot}/bulkOrder/salesOrderStatus`, {id, bulkOrderStatus}).then((res) => res.data);
 };

--- a/src/services/bulkOrderService.ts
+++ b/src/services/bulkOrderService.ts
@@ -26,3 +26,7 @@ export const getBulkOrdersByRangeSvc = async (
 export const bulkOrderMassUpdate = async (id: number, bulkOrderStatus: BulkOrderStatus): Promise<any> => {
   return axios.put(`${apiRoot}/bulkOrder/salesOrderStatus`, {id, bulkOrderStatus}).then((res) => res.data);
 };
+
+export const updateBulkOrderStatusSvc = async (id: number, bulkOrderStatus: BulkOrderStatus): Promise<any> => {
+  return axios.put(`${apiRoot}/bulkOrder/status`, {id, bulkOrderStatus}).then((res) => res.data);
+};


### PR DESCRIPTION
feat: Implemented bulk order details page.
feat: Implemented BulkOrderActionButton to conditionally allow users to cancel/fulfil a bulk order depending on state.
style: implemented `chip` from JJ's PR, improved styling for bulk order grid
fix: added b2b orders to salesOrder logic, can now manage deliveries for b2b orders

todo: 
- allow edit(s) for the details for SalesOrder, such as address/contact etc (to handle cases of b2b wanting to switch address etc.) 