### PR TITLE
Bulk Order cancel & fulfil features fix, and updates to createNewUser

### DIFF
--- a/src/components/sales/bulkOrder/BulkOrderStepper.tsx
+++ b/src/components/sales/bulkOrder/BulkOrderStepper.tsx
@@ -42,7 +42,7 @@ export const BulkOrderSteps = [
     label: 'Order Paid',
     icon: <AccountBalanceWalletRounded sx={{ fontSize: 35 }} />,
     nextAction: 'Bulk Prepare',
-    altAction: 'Complete Order',
+    altAction: 'Fulfil Order',
     tooltip:
       'Bulk prepare the orders, otherwise individually prepare each order.'
   },
@@ -59,7 +59,7 @@ export const BulkOrderSteps = [
 
 const BulkOrderStepper = ({ bulkOrderStatus }: props) => {
   const [activeStep, setActiveStep] = useState<number>(0);
-
+  
   const statusStepper = useMemo(
     () =>
       //Orders always come in paid

--- a/src/pages/account/CreateNewUser.tsx
+++ b/src/pages/account/CreateNewUser.tsx
@@ -19,7 +19,7 @@ import { createUserSvc } from 'src/services/accountService';
 import TimeoutAlert, { AlertType } from 'src/components/common/TimeoutAlert';
 import validator from 'validator';
 
-const roles = Object.keys(UserRole).filter((v) => isNaN(Number(v)));
+const roles = Object.keys(UserRole).filter((v) => isNaN(Number(v)) && (!['CORPORATE', 'CUSTOMER', 'DISTRIBUTOR'].includes(v)));
 
 export type NewUserType = Partial<User>;
 

--- a/src/pages/sales/bulkOrders/BulkOrderDetails.tsx
+++ b/src/pages/sales/bulkOrders/BulkOrderDetails.tsx
@@ -59,7 +59,9 @@ const BulkOrderDetails = () => {
               bo.bulkOrderStatus === BulkOrderStatus.FULFILLED
             )
           ) {
-            bulkOrderLineItems.pop();
+            if (bulkOrderLineItems.length === 6) {
+              bulkOrderLineItems.pop();
+            }
           }
           setLoading(false);
         } else {
@@ -77,7 +79,7 @@ const BulkOrderDetails = () => {
   const bulkOrderPrep = () => {
     setLoading(true);
     asyncFetchCallback(
-      bulkOrderMassUpdate(bulkOrder?.id!, bulkOrder?.bulkOrderStatus!),
+      bulkOrderMassUpdate(bulkOrder?.id!, bulkOrder?.bulkOrderStatus!, OrderStatus.PREPARED),
       () => {
         setBulkOrder({
           ...bulkOrder!,
@@ -127,7 +129,7 @@ const BulkOrderDetails = () => {
           <div className='sales-header-content'>
             <TimeoutAlert alert={alert} clearAlert={() => setAlert(null)} />
             <h1>Bulk Order Details</h1>
-            <BulkOrderStepper bulkOrderStatus={bulkOrder?.bulkOrderStatus!} />
+            {bulkOrder && <BulkOrderStepper bulkOrderStatus={bulkOrder.bulkOrderStatus} />}
             <Paper elevation={3} className='sales-action-card '>
               {bulkOrder && <CustomerInfoGrid bulkOrder={bulkOrder!} />}
               {bulkOrder && (

--- a/src/services/bulkOrderService.ts
+++ b/src/services/bulkOrderService.ts
@@ -1,4 +1,4 @@
-import { BulkOrder, BulkOrderStatus } from 'src/models/types';
+import { BulkOrder, BulkOrderStatus, OrderStatus } from 'src/models/types';
 import axios from 'axios';
 import apiRoot from './util/apiRoot';
 import { MomentRange } from 'src/utils/dateUtils';
@@ -23,10 +23,14 @@ export const getBulkOrdersByRangeSvc = async (
     .then((res) => res.data);
 };
 
-export const bulkOrderMassUpdate = async (id: number, bulkOrderStatus: BulkOrderStatus): Promise<any> => {
-  return axios.put(`${apiRoot}/bulkOrder/salesOrderStatus`, {id, bulkOrderStatus}).then((res) => res.data);
+export const bulkOrderMassUpdate = async (id: number, bulkOrderStatus: BulkOrderStatus, orderStatus: OrderStatus): Promise<any> => {
+  return axios.put(`${apiRoot}/bulkOrder/salesOrderStatus`, {id, bulkOrderStatus, orderStatus}).then((res) => res.data);
 };
 
 export const updateBulkOrderStatusSvc = async (id: number, bulkOrderStatus: BulkOrderStatus): Promise<any> => {
   return axios.put(`${apiRoot}/bulkOrder/status`, {id, bulkOrderStatus}).then((res) => res.data);
+};
+
+export const updateBulkOrderSvc = async (bulkOrder: BulkOrder): Promise<BulkOrder> => {
+  return axios.put(`${apiRoot}/bulkOrder`, bulkOrder).then((res) => res.data);
 };


### PR DESCRIPTION
fix: createNewUser dropdown will not include `CORPORATE` and `DISTRIBUTOR`.
fix: cancelling bulk orders also cancels the individual salesOrders inside.
fix: can only fulfil bulk orders where all salesOrders are marked as delivered.