### PR TITLE
Changes to ViewBusinessAccounts, UserRoles and conditional rendering of actions

### DIFF
--- a/src/components/account/AccountEditGrid.tsx
+++ b/src/components/account/AccountEditGrid.tsx
@@ -8,8 +8,6 @@ interface props {
 }
 
 const AccountEditGrid = ({ editUser, setEditUser }: props) => {
-  const roles = Object.keys(UserRole).filter((v) => isNaN(Number(v)));
-
   const userFieldOnChange = (
     event: React.ChangeEvent<HTMLInputElement>,
     key: string
@@ -108,25 +106,6 @@ const AccountEditGrid = ({ editUser, setEditUser }: props) => {
             userFieldOnChange(e, 'email')
           }
         />
-      </Grid>
-      <Grid item xs={12}>
-        <TextField
-          required
-          fullWidth
-          id='outlined-field'
-          select
-          label='Role'
-          value={editUser?.role}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            userFieldOnChange(e, 'role')
-          }
-        >
-          {roles.map((option) => (
-            <MenuItem key={option} value={option}>
-              {option}
-            </MenuItem>
-          ))}
-        </TextField>
       </Grid>
     </Grid>
   );

--- a/src/components/customers/BulkOrderStatusCell.tsx
+++ b/src/components/customers/BulkOrderStatusCell.tsx
@@ -8,7 +8,7 @@ const BulkOrderStatusCell = ({ row }: GridRenderCellParams) => {
 
   return orderStatus === BulkOrderStatus.PAYMENT_PENDING ? (
     <Chip
-      label='Created'
+      label='Payment Pending'
       style={{ backgroundColor: '#E4F4D8', fontFamily: 'Poppins' }}
     />
   ) : orderStatus === BulkOrderStatus.CANCELLED ? (

--- a/src/components/customers/CustomerBulkOrderGrid.tsx
+++ b/src/components/customers/CustomerBulkOrderGrid.tsx
@@ -68,7 +68,7 @@ export const bulkOrderColumns: GridColDef[] = [
       if (bulkOrderStatus === BulkOrderStatus.CANCELLED) {
         cell = 'Cancelled';
       } else if (bulkOrderStatus === BulkOrderStatus.PAYMENT_PENDING) {
-        cell = 'Created';
+        cell = 'Payment Pending';
       } else if (bulkOrderStatus === BulkOrderStatus.FULFILLED) {
         cell = 'Fulfilled';
       } else if (bulkOrderStatus === BulkOrderStatus.PAYMENT_FAILED) {

--- a/src/components/sales/bulkOrder/BulkOrderStepper.tsx
+++ b/src/components/sales/bulkOrder/BulkOrderStepper.tsx
@@ -15,7 +15,7 @@ interface props {
 export const BulkOrderSteps = [
   {
     currentState: BulkOrderStatus.PAYMENT_PENDING,
-    label: 'Order Placed',
+    label: 'Pending Payment',
     icon: <ReceiptLongRounded sx={{ fontSize: 35 }} />,
     nextAction: 'Confirm Payment',
     altAction: 'Cancel Order',

--- a/src/components/sales/bulkOrder/bulkOrderGridCol.tsx
+++ b/src/components/sales/bulkOrder/bulkOrderGridCol.tsx
@@ -8,6 +8,7 @@ import { createSearchParams } from 'react-router-dom';
 import _ from 'lodash';
 import PaymentModeCell from 'src/components/customers/PaymentModeCell';
 import BulkOrderStatusCell from 'src/components/customers/BulkOrderStatusCell';
+import { OrderStatus } from 'src/models/types';
 
 export const BulkOrderCellAction = ({ id }: GridRenderCellParams) => {
   const navigate = useNavigate();
@@ -27,7 +28,8 @@ export const BulkOrderCellAction = ({ id }: GridRenderCellParams) => {
   );
 };
 
-export const SalesOrderCellAction = ({ id }: GridRenderCellParams) => {
+export const SalesOrderCellAction = ({ id, row }: GridRenderCellParams) => {
+  console.log('row', row);
   const navigate = useNavigate();
   const navToViewBulkOrder = (edit: boolean) =>
     navigate({
@@ -38,9 +40,11 @@ export const SalesOrderCellAction = ({ id }: GridRenderCellParams) => {
     });
   return (
     <div className='action-cell'>
-      <Button variant='contained' onClick={() => navToViewBulkOrder(false)}>
-        View Order
-      </Button>
+      {!(row.orderStatus === 'CREATED' || row.orderStatus === 'CANCELLED') && (
+        <Button variant='contained' onClick={() => navToViewBulkOrder(false)}>
+          View Order
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/components/sales/bulkOrder/bulkOrderGridCol.tsx
+++ b/src/components/sales/bulkOrder/bulkOrderGridCol.tsx
@@ -29,7 +29,6 @@ export const BulkOrderCellAction = ({ id }: GridRenderCellParams) => {
 };
 
 export const SalesOrderCellAction = ({ id, row }: GridRenderCellParams) => {
-  console.log('row', row);
   const navigate = useNavigate();
   const navToViewBulkOrder = (edit: boolean) =>
     navigate({

--- a/src/components/sales/order/OrderInfoEditGrid.tsx
+++ b/src/components/sales/order/OrderInfoEditGrid.tsx
@@ -1,0 +1,115 @@
+import { Grid, TextField } from '@mui/material';
+import React from 'react';
+import { SalesOrder } from 'src/models/types';
+import PlatformChip from './PlatformChip';
+
+interface props {
+  salesOrder: SalesOrder;
+  setSalesOrder: (salesOrder: any) => void;
+}
+
+const OrderInfoEditGrid = ({ salesOrder, setSalesOrder }: props) => {
+  const salesOrderFieldChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    key: string
+  ) => {
+    setSalesOrder((paramSalesOrder: any) => {
+      return {
+        ...paramSalesOrder!,
+        [key]: event.target.value
+      };
+    });
+  };
+
+  return (
+    <div className='order-info-grid'>
+      <Grid container spacing={2}>
+        <Grid item xs={7}>
+          <TextField
+            fullWidth
+            required
+            size="small"
+            id='outlined-quantity'
+            label='Customer Name'
+            name='customerName'
+            placeholder='eg.: John Tan'
+            value={salesOrder.customerName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              salesOrderFieldChange(e, 'customerName')
+            }
+          />
+        </Grid>
+
+        <Grid item xs={7}>
+          <TextField
+            fullWidth
+            required
+            size="small"
+            id='outlined-quantity'
+            label='Contact No'
+            name='customerContactNo'
+            placeholder='eg.: Tan'
+            error={!salesOrder?.customerContactNo}
+            helperText={
+              !salesOrder?.customerContactNo ? 'Contact Number is empty!' : ''
+            }
+            value={salesOrder?.customerContactNo}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              salesOrderFieldChange(e, 'customerContactNo')
+            }
+          />
+        </Grid>
+        <Grid item xs={7}>
+          <TextField
+            fullWidth
+            size="small"
+            id='outlined-quantity'
+            label='Email'
+            name='customerEmail'
+            placeholder='eg.: johntan@gmail.com'
+            value={salesOrder?.customerEmail!}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              salesOrderFieldChange(e, 'customerEmail')
+            }
+          />
+        </Grid>
+        <Grid item xs={7}>
+          <TextField
+            fullWidth
+            required
+            size="small"
+            id='outlined-quantity'
+            label='Shipping Address'
+            name='customerAddress'
+            placeholder='eg.: Tan'
+            error={!salesOrder?.customerAddress}
+            helperText={
+              !salesOrder?.customerAddress ? 'Shipping Address is empty!' : ''
+            }
+            value={salesOrder?.customerAddress}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              salesOrderFieldChange(e, 'customerAddress')
+            }
+          />
+        </Grid>
+        <Grid item xs={7}>
+          <TextField
+            fullWidth
+            size="small"
+            id='outlined-quantity'
+            label='Customer Comments'
+            name='customerRemarks'
+            placeholder='eg.: No spicy ones, thanks'
+            value={salesOrder?.customerRemarks ?? ''}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              salesOrderFieldChange(e, 'customerRemarks')
+            }
+          />
+        </Grid>
+      </Grid>
+      <PlatformChip salesOrder={salesOrder!} />
+    </div>
+  );
+};
+
+export default OrderInfoEditGrid;

--- a/src/models/types/index.ts
+++ b/src/models/types/index.ts
@@ -6,8 +6,7 @@ export enum UserRole {
   PARTTIME = 'PARTTIME',
   FULLTIME = 'FULLTIME',
   CUSTOMER = 'CUSTOMER',
-  DISTRIBUTOR = 'DISTRIBUTOR',
-  CORPORATE = 'CORPORATE'
+  B2B = 'B2B'
 }
 
 export enum UserStatus {

--- a/src/pages/sales/SalesOrderDetails.tsx
+++ b/src/pages/sales/SalesOrderDetails.tsx
@@ -38,6 +38,7 @@ import OrderSummaryCard from '../../components/sales/order/OrderSummaryCard';
 import StatusStepper from '../../components/sales/order/StatusStepper';
 import ConfirmationModal from 'src/components/common/ConfirmationModal';
 import ViewCurrentBundleModal from '../../components/sales/order/ViewCurrentBundleModal';
+import OrderInfoEditGrid from 'src/components/sales/order/OrderInfoEditGrid';
 
 const SalesOrderDetails = () => {
   let params = new URLSearchParams(window.location.search);
@@ -545,7 +546,16 @@ const SalesOrderDetails = () => {
             <StatusStepper orderStatus={salesOrder?.orderStatus!} />
             <TimeoutAlert alert={alert} clearAlert={() => setAlert(null)} />
             <Paper elevation={3} className='sales-action-card '>
-              <OrderInfoGrid salesOrder={salesOrder!} />
+              {salesOrder?.platformType === PlatformType.B2B &&
+              salesOrder?.orderStatus === OrderStatus.PREPARING ? (
+                <OrderInfoEditGrid
+                  salesOrder={salesOrder!}
+                  setSalesOrder={setSalesOrder}
+                />
+              ) : (
+                <OrderInfoGrid salesOrder={salesOrder!} />
+              )}
+
               <div className='action-box'>
                 <Typography sx={{ fontSize: 'inherit' }}>
                   Next Action:

--- a/src/pages/sales/bulkOrders/BulkOrderDetails.tsx
+++ b/src/pages/sales/bulkOrders/BulkOrderDetails.tsx
@@ -40,8 +40,9 @@ const BulkOrderDetails = () => {
   useEffect(() => {
     setLoading(true);
     if (id) {
-      asyncFetchCallback(getBulkOrderByIdSvc(id), (bo: BulkOrder) => {
-        if (bo) {
+      asyncFetchCallback(
+        getBulkOrderByIdSvc(id),
+        (bo: BulkOrder) => {
           setBulkOrder(bo);
           setSalesOrders(bo.salesOrders);
           if (
@@ -52,19 +53,9 @@ const BulkOrderDetails = () => {
           ) {
             setCanBulkPrep(true);
           }
-
-          if (
-            !(
-              bo.bulkOrderStatus === BulkOrderStatus.PAYMENT_SUCCESS ||
-              bo.bulkOrderStatus === BulkOrderStatus.FULFILLED
-            )
-          ) {
-            if (bulkOrderLineItems.length === 6) {
-              bulkOrderLineItems.pop();
-            }
-          }
           setLoading(false);
-        } else {
+        },
+        () => {
           setAlert({
             severity: 'error',
             message: 'Sales Order does not exist. You will be redirected back.'
@@ -72,14 +63,18 @@ const BulkOrderDetails = () => {
           setLoading(false);
           setTimeout(() => navigate(-1), 3500);
         }
-      });
+      );
     }
   }, [id, navigate]);
 
   const bulkOrderPrep = () => {
     setLoading(true);
     asyncFetchCallback(
-      bulkOrderMassUpdate(bulkOrder?.id!, bulkOrder?.bulkOrderStatus!, OrderStatus.PREPARED),
+      bulkOrderMassUpdate(
+        bulkOrder?.id!,
+        bulkOrder?.bulkOrderStatus!,
+        OrderStatus.PREPARED
+      ),
       () => {
         setBulkOrder({
           ...bulkOrder!,
@@ -129,7 +124,9 @@ const BulkOrderDetails = () => {
           <div className='sales-header-content'>
             <TimeoutAlert alert={alert} clearAlert={() => setAlert(null)} />
             <h1>Bulk Order Details</h1>
-            {bulkOrder && <BulkOrderStepper bulkOrderStatus={bulkOrder.bulkOrderStatus} />}
+            {bulkOrder && (
+              <BulkOrderStepper bulkOrderStatus={bulkOrder.bulkOrderStatus} />
+            )}
             <Paper elevation={3} className='sales-action-card '>
               {bulkOrder && <CustomerInfoGrid bulkOrder={bulkOrder!} />}
               {bulkOrder && (


### PR DESCRIPTION
fix: update UserRoles, no longer has CORPORATE or DISTRIBUTOR, now all labelled as B2B.
fix: under ViewBusinessAccounts, when editing a B2B user details, no longer able to set UserRole, all defaults to B2B.
fix: in the BulkOrder::salesOrders grid, conditionally render the "Action" button to not display when the bulk order is pending payment, payment failed or cancelled (clarified w lee)
feat: for salesOrders that are B2B, admin can edit the customer details for that salesOrder only when preparing.
